### PR TITLE
Readme clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Using Swift, sending this subview to the back and [including ObjC in our Swift p
 [objc-swift]:http://stackoverflow.com/a/24102433/1141256
 
 ```swift
+    // sizing background image correctly
+    UIGraphicsBeginImageContext(self.view.frame.size)
+    UIImage(named: "bw.png").drawInRect(self.view.bounds)
+    var resizedImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext()
+    self.view.backgroundColor = UIColor(patternImage:resizedImage)
+        
+    // blurry background like control and notification center
     var translucentView = ILTranslucentView(frame: self.view.frame)
-    translucentView.alpha = 1.0
-    translucentView.backgroundColor = UIColor.clearColor()
-    translucentView.translucentStyle = UIBarStyle.Default
-    translucentView.translucentTintColor = UIColor.clearColor()
+    translucentView.translucentAlpha = 0.78
     self.view.insertSubview(translucentView, atIndex: 0)
-    
-    // background image
-    var backgroundImage:UIImage = UIImage(named: "image.jpg")
-    var background = UIColor(patternImage:backgroundImage)
-    self.view.backgroundColor = background
 ```
 
 #### translucentAlpha


### PR DESCRIPTION
I had some difficulty implementing this in Swift and implementing my own resized background image, so I added an example to the readme.

Also, in my testing on iOS 8B2, I found that this package only adds transparency and doesn't blur the image (as below). We should let iOS 8 become stable before worrying about this issue.

![photo jun 26 8 48 47 pm](https://cloud.githubusercontent.com/assets/1320475/3407023/41ff8cba-fd9e-11e3-871a-f674360b9f30.png)
